### PR TITLE
Feature: support more commit types on release notes sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,18 +68,8 @@ version: "1.0" #config version
 
 versioning: # versioning bump
     update-major: [] # Commit types used to bump major.
-    update-minor: # Commit types used to bump minor.
-        - feat
-    update-patch: # Commit types used to bump patch.
-        - build
-        - ci
-        - chore
-        - docs
-        - fix
-        - perf
-        - refactor
-        - style
-        - test
+    update-minor: [feat] # Commit types used to bump minor.
+    update-patch: [build, ci, chore, fix, perf, refactor, test] # Commit types used to bump patch.
     # When type is not present on update rules and is unknown (not mapped on commit message types);
     # if ignore-unknown=false bump patch, if ignore-unknown=true do not bump version
     ignore-unknown: false
@@ -88,7 +78,10 @@ tag:
     pattern: '%d.%d.%d' # Pattern used to create git tag.
 
 release-notes:
-    headers: # Headers names for release notes markdown. To disable a section just remove the header line.
+    # Headers names for release notes markdown. To disable a section just remove the header line.
+    # It's possible to add other commit types, the release note will be created respecting the following order:
+    # feat, fix, refactor, perf, test, build, ci, chore, docs, style, breaking-change
+    headers: 
         breaking-change: Breaking Changes
         feat: Features
         fix: Bug Fixes
@@ -97,25 +90,11 @@ branches: # Git branches config.
     prefix: ([a-z]+\/)? # Prefix used on branch name, it should be a regex group.
     suffix: (-.*)? # Suffix used on branch name, it should be a regex group.
     disable-issue: false # Set true if there is no need to recover issue id from branch name.
-    skip: # List of branch names ignored on commit message validation.
-        - master
-        - main
-        - developer
+    skip: [master, main, developer] # List of branch names ignored on commit message validation.
     skip-detached: false # Set true if a detached branch should be ignored on commit message validation.
 
 commit-message:
-    types: # Supported commit types.
-        - build
-        - ci
-        - chore
-        - docs
-        - feat
-        - fix
-        - perf
-        - refactor
-        - revert
-        - style
-        - test
+    types: [build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test] # Supported commit types.
     scope:
         # Define supported scopes, if blank, scope will not be validated, if not, only scope listed will be valid.
         # Don't forget to add "" on your list if you need to define scopes and keep it optional.
@@ -123,9 +102,7 @@ commit-message:
     footer:
         issue: # Use "issue: {}" if you wish to disable issue footer.
             key: jira # Name used to define an issue on footer metadata.
-            key-synonyms: # Supported variations for footer metadata.
-                - Jira
-                - JIRA
+            key-synonyms: [Jira, JIRA] # Supported variations for footer metadata.
             use-hash: false # If false, use :<space> separator. If true, use <space># separator.
             add-value-prefix: '' # Add a prefix to issue value.
     issue:

--- a/sv/config.go
+++ b/sv/config.go
@@ -4,7 +4,7 @@ package sv
 
 // CommitMessageConfig config a commit message.
 type CommitMessageConfig struct {
-	Types  []string                             `yaml:"types"`
+	Types  []string                             `yaml:"types,flow"`
 	Scope  CommitMessageScopeConfig             `yaml:"scope"`
 	Footer map[string]CommitMessageFooterConfig `yaml:"footer"`
 	Issue  CommitMessageIssueConfig             `yaml:"issue"`
@@ -26,7 +26,7 @@ type CommitMessageScopeConfig struct {
 // CommitMessageFooterConfig config footer metadata.
 type CommitMessageFooterConfig struct {
 	Key            string   `yaml:"key"`
-	KeySynonyms    []string `yaml:"key-synonyms"`
+	KeySynonyms    []string `yaml:"key-synonyms,flow"`
 	UseHash        bool     `yaml:"use-hash"`
 	AddValuePrefix string   `yaml:"add-value-prefix"`
 }
@@ -43,7 +43,7 @@ type BranchesConfig struct {
 	PrefixRegex  string   `yaml:"prefix"`
 	SuffixRegex  string   `yaml:"suffix"`
 	DisableIssue bool     `yaml:"disable-issue"`
-	Skip         []string `yaml:"skip"`
+	Skip         []string `yaml:"skip,flow"`
 	SkipDetached *bool    `yaml:"skip-detached"`
 }
 
@@ -51,9 +51,9 @@ type BranchesConfig struct {
 
 // VersioningConfig versioning preferences.
 type VersioningConfig struct {
-	UpdateMajor   []string `yaml:"update-major"`
-	UpdateMinor   []string `yaml:"update-minor"`
-	UpdatePatch   []string `yaml:"update-patch"`
+	UpdateMajor   []string `yaml:"update-major,flow"`
+	UpdateMinor   []string `yaml:"update-minor,flow"`
+	UpdatePatch   []string `yaml:"update-patch,flow"`
 	IgnoreUnknown bool     `yaml:"ignore-unknown"`
 }
 

--- a/sv/formatter.go
+++ b/sv/formatter.go
@@ -9,6 +9,7 @@ type releaseNoteTemplateVariables struct {
 	Version         string
 	Date            string
 	Sections        map[string]ReleaseNoteSection
+	Order           []string
 	BreakingChanges BreakingChangeSection
 }
 
@@ -23,13 +24,13 @@ const (
 
 	rnSectionItem = "- {{if .Message.Scope}}**{{.Message.Scope}}:** {{end}}{{.Message.Description}} ({{.Hash}}){{if .Message.Metadata.issue}} ({{.Message.Metadata.issue}}){{end}}"
 
-	rnSection = `{{- if .}}
+	rnSection = `{{- if .}}{{- if ne .Name ""}}
 
 ### {{.Name}}
 {{range $k,$v := .Items}}
 {{template "rnSectionItem" $v}}
 {{- end}}
-{{- end}}`
+{{- end}}{{- end}}`
 
 	rnSectionBreakingChanges = `{{- if ne .Name ""}}
 
@@ -40,8 +41,10 @@ const (
 {{- end}}`
 
 	rnTemplate = `## {{if .Version}}v{{.Version}}{{end}}{{if and .Date .Version}} ({{end}}{{.Date}}{{if and .Version .Date}}){{end}}
-{{- template "rnSection" .Sections.feat}}
-{{- template "rnSection" .Sections.fix}}
+{{- $sections := .Sections }}
+{{- range $key := .Order }}
+{{- template "rnSection" (index $sections $key) }}
+{{- end}}
 {{- template "rnSectionBreakingChanges" .BreakingChanges}}
 `
 )
@@ -101,6 +104,7 @@ func releaseNoteVariables(releasenote ReleaseNote) releaseNoteTemplateVariables 
 		Version:         version,
 		Date:            date,
 		Sections:        releasenote.Sections,
+		Order:           []string{"feat", "fix", "refactor", "perf", "test", "build", "ci", "chore", "docs", "style"},
 		BreakingChanges: releasenote.BreakingChanges,
 	}
 }

--- a/sv/formatter_test.go
+++ b/sv/formatter_test.go
@@ -13,6 +13,24 @@ var emptyDateChangelog = `## v1.0.0
 `
 var emptyVersionChangelog = `## 2020-05-01
 `
+var fullChangeLog = `## v1.0.0 (2020-05-01)
+
+### Features
+
+- subject text ()
+
+### Bug Fixes
+
+- subject text ()
+
+### Build
+
+- subject text ()
+
+### Breaking Changes
+
+- break change message
+`
 
 func TestOutputFormatterImpl_FormatReleaseNote(t *testing.T) {
 	date, _ := time.Parse("2006-01-02", "2020-05-01")
@@ -25,6 +43,7 @@ func TestOutputFormatterImpl_FormatReleaseNote(t *testing.T) {
 		{"with date", emptyReleaseNote("1.0.0", date.Truncate(time.Minute)), dateChangelog},
 		{"without date", emptyReleaseNote("1.0.0", time.Time{}.Truncate(time.Minute)), emptyDateChangelog},
 		{"without version", emptyReleaseNote("", date.Truncate(time.Minute)), emptyVersionChangelog},
+		{"full changelog", fullReleaseNote("1.0.0", date.Truncate(time.Minute)), fullChangeLog},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -44,4 +63,18 @@ func emptyReleaseNote(version string, date time.Time) ReleaseNote {
 		Version: v,
 		Date:    date,
 	}
+}
+
+func fullReleaseNote(version string, date time.Time) ReleaseNote {
+	var v *semver.Version
+	if version != "" {
+		v = semver.MustParse(version)
+	}
+
+	sections := map[string]ReleaseNoteSection{
+		"build": newReleaseNoteSection("Build", []GitCommitLog{commitlog("build", map[string]string{})}),
+		"feat":  newReleaseNoteSection("Features", []GitCommitLog{commitlog("feat", map[string]string{})}),
+		"fix":   newReleaseNoteSection("Bug Fixes", []GitCommitLog{commitlog("fix", map[string]string{})}),
+	}
+	return releaseNote(v, date, sections, []string{"break change message"})
 }


### PR DESCRIPTION
- support refactor, perf, test, build, ci, chore, docs, style as sections on release note
- use yaml flow at some array attributes

Issue: #24 