### PR TITLE
Feature: commit command flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,19 +141,19 @@ git-sv rn -h
 
 ##### Available commands
 
-| Variable                     | description                                                   | has options or subcommands |
-| ---------------------------- | ------------------------------------------------------------- | :------------------------: |
-| config, cfg                  | Show config information.                                      |     :heavy_check_mark:     |
-| current-version, cv          | Get last released version from git.                           |            :x:             |
-| next-version, nv             | Generate the next version based on git commit messages.       |            :x:             |
-| commit-log, cl               | List all commit logs according to range as jsons.             |     :heavy_check_mark:     |
-| commit-notes, cn             | Generate a commit notes according to range.                   |     :heavy_check_mark:     |
-| release-notes, rn            | Generate release notes.                                       |     :heavy_check_mark:     |
-| changelog, cgl               | Generate changelog.                                           |     :heavy_check_mark:     |
-| tag, tg                      | Generate tag with version based on git commit messages.       |            :x:             |
-| commit, cmt                  | Execute git commit with convetional commit message helper.    |            :x:             |
-| validate-commit-message, vcm | Use as prepare-commit-message hook to validate commit message.|     :heavy_check_mark:     |
-| help, h                      | Shows a list of commands or help for one command.             |            :x:             |
+| Variable                     | description                                                    | has options or subcommands |
+| ---------------------------- | -------------------------------------------------------------- | :------------------------: |
+| config, cfg                  | Show config information.                                       |     :heavy_check_mark:     |
+| current-version, cv          | Get last released version from git.                            |            :x:             |
+| next-version, nv             | Generate the next version based on git commit messages.        |            :x:             |
+| commit-log, cl               | List all commit logs according to range as jsons.              |     :heavy_check_mark:     |
+| commit-notes, cn             | Generate a commit notes according to range.                    |     :heavy_check_mark:     |
+| release-notes, rn            | Generate release notes.                                        |     :heavy_check_mark:     |
+| changelog, cgl               | Generate changelog.                                            |     :heavy_check_mark:     |
+| tag, tg                      | Generate tag with version based on git commit messages.        |            :x:             |
+| commit, cmt                  | Execute git commit with convetional commit message helper.     |     :heavy_check_mark:     |
+| validate-commit-message, vcm | Use as prepare-commit-message hook to validate commit message. |     :heavy_check_mark:     |
+| help, h                      | Shows a list of commands or help for one command.              |            :x:             |
 
 ##### Use range
 
@@ -209,17 +209,17 @@ make
 
 #### Make configs
 
-| Variable   | description            |
-| ---------- | ---------------------- |
-| BUILDOS    | Build OS.              |
-| BUILDARCH  | Build arch.            |
-| ECHOFLAGS  | Flags used on echo.    |
-| BUILDENVS  | Var envs used on build.|
-| BUILDFLAGS | Flags used on build.   |
+| Variable   | description             |
+| ---------- | ----------------------- |
+| BUILDOS    | Build OS.               |
+| BUILDARCH  | Build arch.             |
+| ECHOFLAGS  | Flags used on echo.     |
+| BUILDENVS  | Var envs used on build. |
+| BUILDFLAGS | Flags used on build.    |
 
-| Parameters | description                         |
-| ---------- | ----------------------------------- |
-| args       | Parameters that will be used on run.|
+| Parameters | description                          |
+| ---------- | ------------------------------------ |
+| args       | Parameters that will be used on run. |
 
 ```bash
 #variables

--- a/cmd/git-sv/main.go
+++ b/cmd/git-sv/main.go
@@ -149,7 +149,7 @@ func main() {
 				&cli.StringFlag{Name: "type", Aliases: []string{"t"}, Usage: "define commit type"},
 				&cli.StringFlag{Name: "scope", Aliases: []string{"s"}, Usage: "define commit scope"},
 				&cli.StringFlag{Name: "description", Aliases: []string{"d"}, Usage: "define commit description"},
-				&cli.StringFlag{Name: "breaking-change", Aliases: []string{"bc"}, Usage: "define commit breaking change message"},
+				&cli.StringFlag{Name: "breaking-change", Aliases: []string{"b"}, Usage: "define commit breaking change message"},
 			},
 		},
 		{

--- a/cmd/git-sv/main.go
+++ b/cmd/git-sv/main.go
@@ -141,6 +141,16 @@ func main() {
 			Aliases: []string{"cmt"},
 			Usage:   "execute git commit with convetional commit message helper",
 			Action:  commitHandler(cfg, git, messageProcessor),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: "no-scope", Aliases: []string{"nsc"}, Usage: "do not prompt for commit scope"},
+				&cli.BoolFlag{Name: "no-body", Aliases: []string{"nbd"}, Usage: "do not prompt for commit body"},
+				&cli.BoolFlag{Name: "no-issue", Aliases: []string{"nis"}, Usage: "do not prompt for commit issue, will try to recover from branch if enabled"},
+				&cli.BoolFlag{Name: "no-breaking", Aliases: []string{"nbc"}, Usage: "do not prompt for breaking changes"},
+				&cli.StringFlag{Name: "type", Aliases: []string{"t"}, Usage: "define commit type"},
+				&cli.StringFlag{Name: "scope", Aliases: []string{"s"}, Usage: "define commit scope"},
+				&cli.StringFlag{Name: "description", Aliases: []string{"d"}, Usage: "define commit description"},
+				&cli.StringFlag{Name: "breaking-change", Aliases: []string{"bc"}, Usage: "define commit breaking change message"},
+			},
 		},
 		{
 			Name:    "validate-commit-message",

--- a/cmd/git-sv/prompt.go
+++ b/cmd/git-sv/prompt.go
@@ -80,7 +80,7 @@ func promptIssueID(issueLabel, issueRegex, defaultValue string) (string, error) 
 }
 
 func promptBreakingChanges() (string, error) {
-	return promptText("Breaking changes description", "[a-z].+", "")
+	return promptText("Breaking change description", "[a-z].+", "")
 }
 
 func promptSelect(label string, items interface{}, template *promptui.SelectTemplates) (int, error) {

--- a/sv/message_test.go
+++ b/sv/message_test.go
@@ -157,6 +157,71 @@ func TestMessageProcessorImpl_Validate(t *testing.T) {
 	}
 }
 
+func TestMessageProcessorImpl_ValidateType(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     CommitMessageConfig
+		ctype   string
+		wantErr bool
+	}{
+		{"valid type", ccfg, "feat", false},
+		{"invalid type", ccfg, "aaa", true},
+		{"empty type", ccfg, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewMessageProcessor(tt.cfg, newBranchCfg(false))
+			if err := p.ValidateType(tt.ctype); (err != nil) != tt.wantErr {
+				t.Errorf("MessageProcessorImpl.ValidateType() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMessageProcessorImpl_ValidateScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     CommitMessageConfig
+		scope   string
+		wantErr bool
+	}{
+		{"any scope", ccfg, "aaa", false},
+		{"valid scope with scope list", ccfgWithScope, "scope", false},
+		{"invalid scope with scope list", ccfgWithScope, "aaa", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewMessageProcessor(tt.cfg, newBranchCfg(false))
+			if err := p.ValidateScope(tt.scope); (err != nil) != tt.wantErr {
+				t.Errorf("MessageProcessorImpl.ValidateScope() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMessageProcessorImpl_ValidateDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         CommitMessageConfig
+		description string
+		wantErr     bool
+	}{
+		{"empty description", ccfg, "", true},
+		{"sigle letter description", ccfg, "a", false},
+		{"number description", ccfg, "1", true},
+		{"valid description", ccfg, "add some feature", false},
+		{"invalid capital letter description", ccfg, "Add some feature", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewMessageProcessor(tt.cfg, newBranchCfg(false))
+			if err := p.ValidateDescription(tt.description); (err != nil) != tt.wantErr {
+				t.Errorf("MessageProcessorImpl.ValidateDescription() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestMessageProcessorImpl_Enhance(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
- add options to `git sv commit` command

```bash
   --no-scope, --nsc                  do not prompt for commit scope (default: false)
   --no-body, --nbd                   do not prompt for commit body (default: false)
   --no-issue, --nis                  do not prompt for commit issue, will try to recover from branch if enabled (default: false)
   --no-breaking, --nbc               do not prompt for breaking changes (default: false)
   --type value, -t value             define commit type
   --scope value, -s value            define commit scope
   --description value, -d value      define commit description
   --breaking-change value, -b value  define commit breaking change message
   --help, -h                         show help (default: false)

```