### PR TITLE
build: resolves #38 providing arm64 and amd64 releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ endif
 release-all:
 	@rm -rf bin
 
-	VERSION=$(shell git sv nv) BUILDOS=linux make release
-	VERSION=$(shell git sv nv) BUILDOS=darwin make release
-	VERSION=$(shell git sv nv) COMPRESS_TYPE=zip BUILDOS=windows make release
+	VERSION=$(shell git sv nv)                   BUILDOS=linux   BUILDARCH=amd64 make release
+	VERSION=$(shell git sv nv)                   BUILDOS=darwin  BUILDARCH=amd64 make release
+	VERSION=$(shell git sv nv) COMPRESS_TYPE=zip BUILDOS=windows BUILDARCH=amd64 make release
+
+	VERSION=$(shell git sv nv)                   BUILDOS=linux   BUILDARCH=arm64 make release
+	VERSION=$(shell git sv nv)                   BUILDOS=darwin  BUILDARCH=arm64 make release
+	VERSION=$(shell git sv nv) COMPRESS_TYPE=zip BUILDOS=windows BUILDARCH=arm64 make release


### PR DESCRIPTION
Adds 3 new targets `windows, mac, linux` for arm64 Architectures 

Tested on my forked branch.. 
the result was - https://github.com/rbuckland/sv4git/releases/tag/v2.5.1 