### PR TITLE
feat: add --previous option for release-notes

### DIFF
--- a/cmd/git-sv/handlers.go
+++ b/cmd/git-sv/handlers.go
@@ -163,9 +163,10 @@ func releaseNotesHandler(git sv.Git, semverProcessor sv.SemVerCommitsProcessor, 
 		var tag string
 		var date time.Time
 		var err error
+		previous := c.String("p")
 
 		if tag = c.String("t"); tag != "" {
-			rnVersion, date, commits, err = getTagVersionInfo(git, tag)
+			rnVersion, date, commits, err = getTagVersionInfo(git, tag, previous)
 		} else {
 			// TODO: should generate release notes if version was not updated?
 			rnVersion, _, date, commits, err = getNextVersionInfo(git, semverProcessor)
@@ -185,12 +186,16 @@ func releaseNotesHandler(git sv.Git, semverProcessor sv.SemVerCommitsProcessor, 
 	}
 }
 
-func getTagVersionInfo(git sv.Git, tag string) (*semver.Version, time.Time, []sv.GitCommitLog, error) {
+func getTagVersionInfo(git sv.Git, tag string, explicitPreviousTag string) (*semver.Version, time.Time, []sv.GitCommitLog, error) {
 	tagVersion, _ := sv.ToVersion(tag)
 
 	previousTag, currentTag, err := getTags(git, tag)
 	if err != nil {
 		return nil, time.Time{}, nil, fmt.Errorf("error listing tags, message: %v", err)
+	}
+
+	if explicitPreviousTag != "" {
+		previousTag = explicitPreviousTag
 	}
 
 	commits, err := git.Log(sv.NewLogRange(sv.TagRange, previousTag, tag))

--- a/cmd/git-sv/main.go
+++ b/cmd/git-sv/main.go
@@ -112,7 +112,10 @@ func main() {
 			Aliases: []string{"rn"},
 			Usage:   "generate release notes",
 			Action:  releaseNotesHandler(git, semverProcessor, releasenotesProcessor, outputFormatter),
-			Flags:   []cli.Flag{&cli.StringFlag{Name: "t", Aliases: []string{"tag"}, Usage: "get release note from tag"}},
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "t", Aliases: []string{"tag"}, Usage: "get release note from tag"},
+				&cli.StringFlag{Name: "p", Aliases: []string{"previous"}, Usage: "previous tag to use"},
+			},
 		},
 		{
 			Name:    "changelog",


### PR DESCRIPTION
When trying to generate release notes for RC releases, I could not find a way how to configure sv4git to actually generate release notes from the latest release (e.g. v0.17.0) rather than latest RC (v0.18.0-rc.0) when trying to bump the RC (e.g. to v0.18.0-rc.1).

To fix this I am introducing a `--previous` option for `release-notes` command which overrides `previousTag` variable in `getTagVersionInfo`

This allows me to explicitly select the start (new RC tag) and end (latest release) tags to generate the release notes. E.g.

```
$ git tag -l --sort -creatordate
v0.18.0-rc.1
v0.18.0-rc.0
v0.17.0
v0.16.0
$ git-sv release-notes -t v0.18.0-rc.1 --previous $(git tag -l --sort -creatordate | grep -e "^v[0-9]*\.[0-9]*\.[0-9]*$")
...
```

i.e. generate release notes for `v0.18.0-rc.1`, but instead of using previous latest tag (`v0.18.0-rc.0`), use latest tag matching the regex (i.e. `v0.17.0`) for my case