### PR TITLE
feat: use git describe to find current version

### DIFF
--- a/sv/git.go
+++ b/sv/git.go
@@ -83,7 +83,11 @@ func NewGit(messageProcessor MessageProcessor, cfg TagConfig) *GitImpl {
 
 // LastTag get last tag, if no tag found, return empty.
 func (g GitImpl) LastTag() string {
-	cmd := exec.Command("git", "for-each-ref", "refs/tags/"+*g.tagCfg.Filter, "--sort", "-creatordate", "--format", "%(refname:short)", "--count", "1")
+	match := *g.tagCfg.Filter
+	if match == "" {
+		match = "*"
+	}
+	cmd := exec.Command("git", "describe", "--abbrev=0", "--match="+match)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return ""


### PR DESCRIPTION
## Proposed change

Will return first ancestor tag as current version instead of last tag created by date.

fixes #105

This allows support for out-of-sequence hotfix or patch version tags without disrupting the current-version reported in other branches built on a different commit history.